### PR TITLE
Use chars with iterators for performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,23 +25,33 @@ mod tests {
     }
 }
 
-const TALLY_MARKS: [&str; 6] = ["", "𝍩", "𝍪", "𝍫", "𝍬", "𝍸"];
+const TALLY_MARKS: [char; 5] = ['𝍩', '𝍪', '𝍫', '𝍬', '𝍸'];
 
-pub fn tally_marks(n: usize) -> String {
+fn gen_marks(n: usize) -> impl Iterator<Item = char> {
     let full = n / 5;
     let rem = n % 5;
 
-    let rem_str = TALLY_MARKS[rem];
+    let rem_char = if rem != 0 {
+        Some(TALLY_MARKS[rem - 1])
+    } else {
+        None
+    };
 
-    TALLY_MARKS[5].repeat(full) + rem_str
+    std::iter::repeat(TALLY_MARKS[4]).take(full).chain(rem_char)
+}
+
+pub fn tally_marks(n: usize) -> String {
+    String::from_iter(gen_marks(n))
 }
 
 pub fn tally_marks_spaced(n: usize) -> String {
-    tally_marks(n).chars().fold(String::new(), |acc, c| {
-        if acc != "" {
-            format!("{} {}", acc, c)
-        } else {
-            format!("{}{}", acc, c)
+    let mut chars = gen_marks(n).peekable();
+    let mut marks = String::with_capacity(chars.size_hint().0 * 4);
+    while let Some(c) = chars.next() {
+        marks.push(c);
+        if chars.peek().is_some() {
+            marks.push(' ')
         }
-    })
+    }
+    marks
 }


### PR DESCRIPTION
As an exercise I decided to improve the performance of this crate a bit.
Changes:
 - Change TALLY_MARKS array to contain single unicode characters instead of single-char &str-s
 - Use a common function for creating an iterator of chars
 - Allocate once (instead of twice) in the `tally_marks` function
 - Allocate once (instead of n + 1 times) in the `tally_marks_spaced` function and avoid the `format!` macro

The `tally_marks_spaced` function can be improved by using [`Iterator::Intersperse`](https://github.com/rust-lang/rust/issues/79524) when it reaches stable.

I benchmarked both versions with this simple test:
![latest-screenshot_640](https://user-images.githubusercontent.com/18427061/163715393-e988a1ec-4cb5-4537-be32-66cbd91c1f5f.png)

The hyperfine benchmark results show that the new version is performing much better:
![latest-screenshot_639](https://user-images.githubusercontent.com/18427061/163715505-16311e25-56bd-4eb8-9e94-a207300e970e.png)

